### PR TITLE
Fixed copyrights in the CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/src/controls/CMakeLists.txt
+++ b/src/controls/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/src/imports/CMakeLists.txt
+++ b/src/imports/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/src/templates/CMakeLists.txt
+++ b/src/templates/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/controls/CMakeLists.txt
+++ b/tests/auto/controls/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/CMakeLists.txt
+++ b/tests/auto/templates/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/control/CMakeLists.txt
+++ b/tests/auto/templates/control/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/internal/CMakeLists.txt
+++ b/tests/auto/templates/internal/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/internal/style/CMakeLists.txt
+++ b/tests/auto/templates/internal/style/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/internal/style/abstractstyledispatcher/CMakeLists.txt
+++ b/tests/auto/templates/internal/style/abstractstyledispatcher/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/internal/style/stylepropertychanges/CMakeLists.txt
+++ b/tests/auto/templates/internal/style/stylepropertychanges/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/internal/style/stylepropertyexpression/CMakeLists.txt
+++ b/tests/auto/templates/internal/style/stylepropertyexpression/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/internal/style/stylestatecontroller/CMakeLists.txt
+++ b/tests/auto/templates/internal/style/stylestatecontroller/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/internal/style/stylestateoperation/CMakeLists.txt
+++ b/tests/auto/templates/internal/style/stylestateoperation/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/padding/CMakeLists.txt
+++ b/tests/auto/templates/padding/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/public/CMakeLists.txt
+++ b/tests/auto/templates/public/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/public/core/CMakeLists.txt
+++ b/tests/auto/templates/public/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/public/core/exception/CMakeLists.txt
+++ b/tests/auto/templates/public/core/exception/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/public/core/exception/exception/CMakeLists.txt
+++ b/tests/auto/templates/public/core/exception/exception/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/public/core/exception/exceptionhandler/CMakeLists.txt
+++ b/tests/auto/templates/public/core/exception/exceptionhandler/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##

--- a/tests/auto/templates/public/core/exception/nullpointerexception/CMakeLists.txt
+++ b/tests/auto/templates/public/core/exception/nullpointerexception/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 ##                                                                                                ##
-##            Copyright (C) 2015-2016 William McKIE                                               ##
+##            Copyright (C) 2016 William McKIE                                                    ##
 ##                                                                                                ##
 ##            This program is free software: you can redistribute it and/or modify                ##
 ##            it under the terms of the GNU General Public License as published by                ##


### PR DESCRIPTION
This was not the right year shown in the licence header.